### PR TITLE
Enforce default gateway for providers

### DIFF
--- a/Passepartout/Sources/Model/Profiles/ProviderConnectionProfile.swift
+++ b/Passepartout/Sources/Model/Profiles/ProviderConnectionProfile.swift
@@ -166,6 +166,7 @@ public class ProviderConnectionProfile: ConnectionProfile, Codable, Equatable {
 //                EndpointProtocol(.tcp, 443)
 //            ]
         }
+        sessionBuilder.routingPolicies = [.IPv4, .IPv6]
         builder.sessionConfiguration = sessionBuilder.build()
         
         return builder.build()


### PR DESCRIPTION
E.g. TunnelBear has `redirect-gateway` set in its .ovpn files, but the setting is not retained when ported to the Passepartout API -there's no counterpart.

Therefore, assume that ALL providers are default gateway out of the box.